### PR TITLE
Hotfix autofocus with timer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ class ShakyCanvasComponent extends Component {
   }
 
   focusTextarea() {
-    this.refs.reactShakyTextarea.focus();
+    setTimeout(() => this.refs.reactShakyTextarea.focus(), 0);
   }
 
   handleUpdateDiagram(e) {


### PR DESCRIPTION
- Fix auto focus to `textarea` after double click `shaky diagram`
